### PR TITLE
Add Oliver Terbu and Timothée Haudebourg to the editors list and `CODEOWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a 
 # pull request.
-*       @msporny @tplooker @clehner
+*       @msporny @tplooker @clehner @timothee-haudebourg @awoie
 
 # See CODEOWNERS syntax here: https://help.github.com/articles/about-codeowners/#codeowners-syntax

--- a/index.html
+++ b/index.html
@@ -53,6 +53,12 @@
         }, {
           name: "Tobias Looker", url: "https://www.linkedin.com/in/tplooker/",
           company: "MATTR", companyURL: "https://mattr.global/"
+        }, {
+          name: "Timothée Haudebourg", url: "https://github.com/timothee-haudebourg/",
+          company: "Spruce Systems, Inc.", companyURL: "https://spruceid.com/"
+        }, {
+          name: "Oliver Terbu", url: "https://github.com/awoie",
+          company: "Spruce Systems, Inc.", companyURL: "https://spruceid.com/"
         }],
 
         // extend the bibliography entries


### PR DESCRIPTION
Updates the `CODEOWNERS` file and editors list in `index.html` to add Oliver Terbu and myself, representing SpruceId. I hope the syntax is correct in both cases.