### PR TITLE
Align the vocabulary with ISO mDL & add AAMVA vocabulary

### DIFF
--- a/context/aamva/v1.jsonld
+++ b/context/aamva/v1.jsonld
@@ -1,0 +1,57 @@
+{
+  "@context": {
+    "@protected": true,
+    "org.iso.18013.5.1.aamva": {
+      "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva",
+      "@context": {
+        "@protected": true,
+        "aka_family_name_v2": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#akaFamilyNameV2",
+        "aka_given_name_v2": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#akaGivenNameV2",
+        "aka_suffix": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#akaSuffix",
+        "cdl_indicator": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#cdlIndicator",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "dhs_compliance": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#dhsCompliance",
+        "dhs_compliance_text": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#dhsCompliance_text",
+        "dhs_temporary_lawful_status": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#dhsTemporaryLawfulStatus",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "domestic_driving_privileges": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#domesticDrivingPrivileges",
+          "@type": "@json"
+        },
+        "edl_credential": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#edlCredential",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "family_name_truncation": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#familyNameTruncation",
+        "given_name_truncation": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#givenNameTruncation",
+        "hazmat_endorsement_expiration_date": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#hazmatEndorsementExpirationDate",
+          "@type": "https://www.rfc-editor.org/rfc/rfc3339#full-date"
+        },
+        "name_suffix": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#nameSuffix",
+        "organ_donor": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#organDonor",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "race_ethnicity": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#raceEthnicity",
+        "resident_county": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#residentCounty",
+        "sex": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#sex",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "veteran": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#veteran",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "weight_range": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#weightRange",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        }
+      }
+    }
+  }
+}

--- a/context/aamva/v1.jsonld
+++ b/context/aamva/v1.jsonld
@@ -1,57 +1,51 @@
 {
   "@context": {
     "@protected": true,
-    "org.iso.18013.5.1.aamva": {
-      "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva",
-      "@context": {
-        "@protected": true,
-        "aka_family_name_v2": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#akaFamilyNameV2",
-        "aka_given_name_v2": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#akaGivenNameV2",
-        "aka_suffix": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#akaSuffix",
-        "cdl_indicator": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#cdlIndicator",
-          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
-        },
-        "dhs_compliance": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#dhsCompliance",
-        "dhs_compliance_text": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#dhsCompliance_text",
-        "dhs_temporary_lawful_status": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#dhsTemporaryLawfulStatus",
-          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
-        },
-        "domestic_driving_privileges": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#domesticDrivingPrivileges",
-          "@type": "@json"
-        },
-        "edl_credential": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#edlCredential",
-          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
-        },
-        "family_name_truncation": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#familyNameTruncation",
-        "given_name_truncation": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#givenNameTruncation",
-        "hazmat_endorsement_expiration_date": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#hazmatEndorsementExpirationDate",
-          "@type": "https://www.rfc-editor.org/rfc/rfc3339#full-date"
-        },
-        "name_suffix": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#nameSuffix",
-        "organ_donor": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#organDonor",
-          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
-        },
-        "race_ethnicity": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#raceEthnicity",
-        "resident_county": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#residentCounty",
-        "sex": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#sex",
-          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
-        },
-        "veteran": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#veteran",
-          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
-        },
-        "weight_range": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1.aamva#weightRange",
-          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
-        }
-      }
+    "aamva_aka_family_name_v2": "https://w3id.org/vdl/aamva#akaFamilyNameV2",
+    "aamva_aka_given_name_v2": "https://w3id.org/vdl/aamva#akaGivenNameV2",
+    "aamva_aka_suffix": "https://w3id.org/vdl/aamva#akaSuffix",
+    "aamva_cdl_indicator": {
+      "@id": "https://w3id.org/vdl/aamva#cdlIndicator",
+      "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+    },
+    "aamva_dhs_compliance": "https://w3id.org/vdl/aamva#dhsCompliance",
+    "aamva_dhs_compliance_text": "https://w3id.org/vdl/aamva#dhsCompliance_text",
+    "aamva_dhs_temporary_lawful_status": {
+      "@id": "https://w3id.org/vdl/aamva#dhsTemporaryLawfulStatus",
+      "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+    },
+    "aamva_domestic_driving_privileges": {
+      "@id": "https://w3id.org/vdl/aamva#domesticDrivingPrivileges",
+      "@type": "@json"
+    },
+    "aamva_edl_credential": {
+      "@id": "https://w3id.org/vdl/aamva#edlCredential",
+      "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+    },
+    "aamva_family_name_truncation": "https://w3id.org/vdl/aamva#familyNameTruncation",
+    "aamva_given_name_truncation": "https://w3id.org/vdl/aamva#givenNameTruncation",
+    "aamva_hazmat_endorsement_expiration_date": {
+      "@id": "https://w3id.org/vdl/aamva#hazmatEndorsementExpirationDate",
+      "@type": "https://www.rfc-editor.org/rfc/rfc3339#full-date"
+    },
+    "aamva_name_suffix": "https://w3id.org/vdl/aamva#nameSuffix",
+    "aamva_organ_donor": {
+      "@id": "https://w3id.org/vdl/aamva#organDonor",
+      "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+    },
+    "aamva_race_ethnicity": "https://w3id.org/vdl/aamva#raceEthnicity",
+    "aamva_resident_county": "https://w3id.org/vdl/aamva#residentCounty",
+    "aamva_sex": {
+      "@id": "https://w3id.org/vdl/aamva#sex",
+      "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+    },
+    "aamva_veteran": {
+      "@id": "https://w3id.org/vdl/aamva#veteran",
+      "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+    },
+    "aamva_weight_range": {
+      "@id": "https://w3id.org/vdl/aamva#weightRange",
+      "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
     }
   }
 }

--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -8,81 +8,80 @@
       "@type": "@id"
     },
     "Iso18013DriversLicenseCredential": "https://w3id.org/vdl#Iso18013DriversLicenseCredential",
-    "Iso18013DriversLicense": "https://w3id.org/vdl#Iso18013DriversLicense",
-    "org.iso.18013.5.1": {
-      "@id": "https://w3id.org/vdl/org.iso.18013.5.1",
+    "Iso18013DriversLicense": {
+      "@id": "https://w3id.org/vdl#Iso18013DriversLicense",
       "@context": {
         "@protected": true,
-        "administrative_number": "https://w3id.org/vdl/org.iso.18013.5.1#administrativeNumber",
+        "administrative_number": "https://w3id.org/vdl#administrativeNumber",
         "age_birth_year": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#ageBirthYear",
+          "@id": "https://w3id.org/vdl#ageBirthYear",
           "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
         "age_in_years": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#ageInYears",
+          "@id": "https://w3id.org/vdl#ageInYears",
           "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
-        "age_over_18": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver18",
-        "age_over_21": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver21",
-        "age_over_25": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver25",
-        "age_over_62": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver62",
-        "age_over_65": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver65",
+        "age_over_18": "https://w3id.org/vdl#ageOver18",
+        "age_over_21": "https://w3id.org/vdl#ageOver21",
+        "age_over_25": "https://w3id.org/vdl#ageOver25",
+        "age_over_62": "https://w3id.org/vdl#ageOver62",
+        "age_over_65": "https://w3id.org/vdl#ageOver65",
         "birth_date": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#birthDate",
+          "@id": "https://w3id.org/vdl#birthDate",
           "@type": "https://www.rfc-editor.org/rfc/rfc3339#full-date"
         },
-        "birth_place": "https://w3id.org/vdl/org.iso.18013.5.1#birthPlace",
-        "document_number": "https://w3id.org/vdl/org.iso.18013.5.1#documentNumber",
+        "birth_place": "https://w3id.org/vdl#birthPlace",
+        "document_number": "https://w3id.org/vdl#documentNumber",
         "driving_privileges": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#drivingPrivileges",
+          "@id": "https://w3id.org/vdl#drivingPrivileges",
           "@type": "@json"
         },
         "expiry_date": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#expiryDate",
+          "@id": "https://w3id.org/vdl#expiryDate",
           "@type": "https://w3id.org/vdl#date-time-or-full-date"
         },
-        "eye_colour": "https://w3id.org/vdl/org.iso.18013.5.1#eyeColour",
-        "family_name": "https://w3id.org/vdl/org.iso.18013.5.1#familyName",
-        "family_name_national_character": "https://w3id.org/vdl/org.iso.18013.5.1#familyNameNationalCharacter",
-        "given_name": "https://w3id.org/vdl/org.iso.18013.5.1#givenName",
-        "given_name_national_character": "https://w3id.org/vdl/org.iso.18013.5.1#givenNameNationalCharacter",
-        "hair_colour": "https://w3id.org/vdl/org.iso.18013.5.1#hairColour",
+        "eye_colour": "https://w3id.org/vdl#eyeColour",
+        "family_name": "https://w3id.org/vdl#familyName",
+        "family_name_national_character": "https://w3id.org/vdl#familyNameNationalCharacter",
+        "given_name": "https://w3id.org/vdl#givenName",
+        "given_name_national_character": "https://w3id.org/vdl#givenNameNationalCharacter",
+        "hair_colour": "https://w3id.org/vdl#hairColour",
         "height": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#height",
+          "@id": "https://w3id.org/vdl#height",
           "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
         "issue_date": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#issueDate",
+          "@id": "https://w3id.org/vdl#issueDate",
           "@type": "https://w3id.org/vdl#date-time-or-full-date"
         },
-        "issuing_authority": "https://w3id.org/vdl/org.iso.18013.5.1#issuingAuthority",
-        "issuing_country": "https://w3id.org/vdl/org.iso.18013.5.1#issuingCountry",
-        "issuing_jurisdiction": "https://w3id.org/vdl/org.iso.18013.5.1#issuingJurisdiction",
-        "nationality": "https://w3id.org/vdl/org.iso.18013.5.1#nationality",
+        "issuing_authority": "https://w3id.org/vdl#issuingAuthority",
+        "issuing_country": "https://w3id.org/vdl#issuingCountry",
+        "issuing_jurisdiction": "https://w3id.org/vdl#issuingJurisdiction",
+        "nationality": "https://w3id.org/vdl#nationality",
         "portrait": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#portrait",
+          "@id": "https://w3id.org/vdl#portrait",
           "@type": "http://www.w3.org/2001/XMLSchema#base64Binary"
         },
         "portrait_capture_date": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#portraitCaptureDate",
+          "@id": "https://w3id.org/vdl#portraitCaptureDate",
           "@type": "https://www.rfc-editor.org/rfc/rfc3339#date-time"
         },
-        "resident_address": "https://w3id.org/vdl/org.iso.18013.5.1#residentAddress",
-        "resident_city": "https://w3id.org/vdl/org.iso.18013.5.1#residentCity",
-        "resident_country": "https://w3id.org/vdl/org.iso.18013.5.1#residentCountry",
-        "resident_postal_code": "https://w3id.org/vdl/org.iso.18013.5.1#residentPostalCode",
-        "resident_state": "https://w3id.org/vdl/org.iso.18013.5.1#residentState",
+        "resident_address": "https://w3id.org/vdl#residentAddress",
+        "resident_city": "https://w3id.org/vdl#residentCity",
+        "resident_country": "https://w3id.org/vdl#residentCountry",
+        "resident_postal_code": "https://w3id.org/vdl#residentPostalCode",
+        "resident_state": "https://w3id.org/vdl#residentState",
         "sex": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#sex",
+          "@id": "https://w3id.org/vdl#sex",
           "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
         "signature_usual_mark": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#signatureUsualMark",
+          "@id": "https://w3id.org/vdl#signatureUsualMark",
           "@type": "http://www.w3.org/2001/XMLSchema#base64Binary"
         },
-        "un_distinguishing_sign": "https://w3id.org/vdl/org.iso.18013.5.1#unDistinguishingSign",
+        "un_distinguishing_sign": "https://w3id.org/vdl#unDistinguishingSign",
         "weight": {
-          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#weight",
+          "@id": "https://w3id.org/vdl#weight",
           "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         }
       }

--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -3,106 +3,87 @@
     "@protected": true,
     "id": "@id",
     "type": "@type",
-    "license": {
+    "driversLicense": {
       "@id": "https://w3id.org/vdl#license",
       "@type": "@id"
     },
     "Iso18013DriversLicenseCredential": "https://w3id.org/vdl#Iso18013DriversLicenseCredential",
-    "Iso18013DriversLicense": {
-      "@id": "https://w3id.org/vdl#Iso18013DriversLicense",
+    "Iso18013DriversLicense": "https://w3id.org/vdl#Iso18013DriversLicense",
+    "org.iso.18013.5.1": {
+      "@id": "https://w3id.org/vdl/org.iso.18013.5.1",
       "@context": {
         "@protected": true,
-        "id": "@id",
-        "type": "@type",
-        "family_name": {
-          "@id": "https://w3id.org/vdl#family_name"
-        },
-        "given_name": {
-          "@id": "https://w3id.org/vdl#given_name"
-        },
-        "birth_date": {
-          "@id": "https://w3id.org/vdl#birth_date"
-        },
-        "issue_date": {
-          "@id": "https://w3id.org/vdl#issue_date",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "expiry_date": {
-          "@id": "https://w3id.org/vdl#expiry_date",
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
-        },
-        "issuing_country": {
-          "@id": "https://w3id.org/vdl#issuing_country"
-        },
-        "issuing_authority": {
-          "@id": "https://w3id.org/vdl#issuing_authority"
-        },
-        "document_number": {
-          "@id": "https://w3id.org/vdl#document_number"
-        },
-        "administrative_number": {
-          "@id": "https://w3id.org/vdl#administrative_number"
-        },
-        "driving_privileges": {
-          "@id": "https://w3id.org/vdl#driving_privileges",
-          "@type": "@json"
-        },
-        "un_distinguishing_sign": {
-          "@id": "https://w3id.org/vdl#un_distinguishing_sign"
-        },
-        "gender": {
-          "@id": "https://w3id.org/vdl#gender"
-        },
-        "height": {
-          "@id": "https://w3id.org/vdl#height"
-        },
-        "weight": {
-          "@id": "https://w3id.org/vdl#weight"
-        },
-        "eye_color": {
-          "@id": "https://w3id.org/vdl#eye_color"
-        },
-        "hair_color": {
-          "@id": "https://w3id.org/vdl#hair_color"
-        },
-        "birth_place": {
-          "@id": "https://w3id.org/vdl#birth_place"
-        },
-        "resident_address": {
-          "@id": "https://w3id.org/vdl#resident_address"
-        },
-        "portrait": {
-          "@id": "https://w3id.org/vdl#portrait"
-        },
-        "portrait_capture_date": {
-          "@id": "https://w3id.org/vdl#portrait_capture_date"
+        "administrative_number": "https://w3id.org/vdl/org.iso.18013.5.1#administrativeNumber",
+        "age_birth_year": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#ageBirthYear",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
         "age_in_years": {
-          "@id": "https://w3id.org/vdl#age_in_years"
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#ageInYears",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
-        "age_birth_year": {
-          "@id": "https://w3id.org/vdl#age_birth_year"
+        "age_over_18": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver18",
+        "age_over_21": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver21",
+        "age_over_25": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver25",
+        "age_over_62": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver62",
+        "age_over_65": "https://w3id.org/vdl/org.iso.18013.5.1#ageOver65",
+        "birth_date": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#birthDate",
+          "@type": "https://www.rfc-editor.org/rfc/rfc3339#full-date"
         },
-        "issuing_jurisdiction": {
-          "@id": "https://w3id.org/vdl#issuing_jurisdiction"
+        "birth_place": "https://w3id.org/vdl/org.iso.18013.5.1#birthPlace",
+        "document_number": "https://w3id.org/vdl/org.iso.18013.5.1#documentNumber",
+        "driving_privileges": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#drivingPrivileges",
+          "@type": "@json"
         },
-        "nationality": {
-          "@id": "https://w3id.org/vdl#nationality"
+        "expiry_date": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#expiryDate",
+          "@type": "https://w3id.org/vdl#date-time-or-full-date"
         },
-        "resident_city": {
-          "@id": "https://w3id.org/vdl#resident_city"
+        "eye_colour": "https://w3id.org/vdl/org.iso.18013.5.1#eyeColour",
+        "family_name": "https://w3id.org/vdl/org.iso.18013.5.1#familyName",
+        "family_name_national_character": "https://w3id.org/vdl/org.iso.18013.5.1#familyNameNationalCharacter",
+        "given_name": "https://w3id.org/vdl/org.iso.18013.5.1#givenName",
+        "given_name_national_character": "https://w3id.org/vdl/org.iso.18013.5.1#givenNameNationalCharacter",
+        "hair_colour": "https://w3id.org/vdl/org.iso.18013.5.1#hairColour",
+        "height": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#height",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
-        "resident_state": {
-          "@id": "https://w3id.org/vdl#resident_state"
+        "issue_date": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#issueDate",
+          "@type": "https://w3id.org/vdl#date-time-or-full-date"
         },
-        "resident_postal_code": {
-          "@id": "https://w3id.org/vdl#resident_postal_code"
+        "issuing_authority": "https://w3id.org/vdl/org.iso.18013.5.1#issuingAuthority",
+        "issuing_country": "https://w3id.org/vdl/org.iso.18013.5.1#issuingCountry",
+        "issuing_jurisdiction": "https://w3id.org/vdl/org.iso.18013.5.1#issuingJurisdiction",
+        "nationality": "https://w3id.org/vdl/org.iso.18013.5.1#nationality",
+        "portrait": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#portrait",
+          "@type": "http://www.w3.org/2001/XMLSchema#base64Binary"
         },
-        "name_national_character": {
-          "@id": "https://w3id.org/vdl#name_national_character"
+        "portrait_capture_date": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#portraitCaptureDate",
+          "@type": "https://www.rfc-editor.org/rfc/rfc3339#date-time"
+        },
+        "resident_address": "https://w3id.org/vdl/org.iso.18013.5.1#residentAddress",
+        "resident_city": "https://w3id.org/vdl/org.iso.18013.5.1#residentCity",
+        "resident_country": "https://w3id.org/vdl/org.iso.18013.5.1#residentCountry",
+        "resident_postal_code": "https://w3id.org/vdl/org.iso.18013.5.1#residentPostalCode",
+        "resident_state": "https://w3id.org/vdl/org.iso.18013.5.1#residentState",
+        "sex": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#sex",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         },
         "signature_usual_mark": {
-          "@id": "https://w3id.org/vdl#signature_usual_mark"
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#signatureUsualMark",
+          "@type": "http://www.w3.org/2001/XMLSchema#base64Binary"
+        },
+        "un_distinguishing_sign": "https://w3id.org/vdl/org.iso.18013.5.1#unDistinguishingSign",
+        "weight": {
+          "@id": "https://w3id.org/vdl/org.iso.18013.5.1#weight",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         }
       }
     }

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@ Compatability with the W3C Verifiable Credentials data model.
           The following examples are provided  ...
         </p>
 
-        <pre class="example" title="A ISO18013-5 mDL expressed as a W3C Verifiable Credential featuring an Ed25519 Digital Signature">
+        <pre class="example" title="A ISO18013-5 mDL expressed as a W3C Verifiable Credential">
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
@@ -156,46 +156,33 @@ Compatability with the W3C Verifiable Credentials data model.
     "id": "did:example:12347abcd",
     "driversLicense": {
       "type": "Iso18013DriversLicense",
-      "org.iso.18013.5.1": {
-        "document_number": "542426814",
-        "family_name": "TURNER",
-        "given_name": "SUSAN",
-        "portrait": "/9j/4AAQSkZJRgABAQEAkACQA...gcdgck5HtRRSClooooP/2Q==",
-        "birth_date": "1998-08-28",
-        "issue_date": "2018-01-15T10:00:00.0000000-07:00",
-        "expiry_date": "2022-08-27T12:00:00.0000000-06:00",
-        "issuing_country": "US",
-        "issuing_authority": "CO",
-        "driving_privileges": [{
-          "codes": [{"code": "D"}],
-          "vehicle_category_code": "D",
-          "issue_date": "2019-01-01",
-          "expiry_date": "2027-01-01"
-        },
-        {
-          "codes": [{"code": "C"}],
-          "vehicle_category_code": "C",
-          "issue_date": "2019-01-01",
-          "expiry_date": "2017-01-01"
-        }],
-        "un_distinguishing_sign": "USA",
+      "document_number": "542426814",
+      "family_name": "TURNER",
+      "given_name": "SUSAN",
+      "portrait": "/9j/4AAQSkZJRgABAQEAkACQA...gcdgck5HtRRSClooooP/2Q==",
+      "birth_date": "1998-08-28",
+      "issue_date": "2018-01-15T10:00:00.0000000-07:00",
+      "expiry_date": "2022-08-27T12:00:00.0000000-06:00",
+      "issuing_country": "US",
+      "issuing_authority": "CO",
+      "driving_privileges": [{
+        "codes": [{"code": "D"}],
+        "vehicle_category_code": "D",
+        "issue_date": "2019-01-01",
+        "expiry_date": "2027-01-01"
       },
-      "org.iso.18013.5.1.aamva": {
-        "aka_suffix": "1ST",
-        "sex": 2,
-        "family_name_truncation": "N",
-        "given_name_truncation": "N"
-      }
-    },
-  },
-  "proof": {
-    "type": "Ed25519Signature2020",
-    "created": "2021-06-20T00:17:01Z",
-    "verificationMethod": "did:key:z6MkjxvA4FNrQUhr8f7xhdQuP1VPzErkcnfxsRaU5oFgy2E5
-      #z6MkjxvA4FNrQUhr8f7xhdQuP1VPzErkcnfxsRaU5oFgy2E5",
-    "proofPurpose": "assertionMethod",
-    "proofValue": "z4zKSH1WmuSQ8tcpSB6mtaSGhtzvMnBQSckqrpTDm3wQyNfHd6rctuST2
-      cyzaKSY135Kp6ZYMyFaiLvBUjJ89GP7V"
+      {
+        "codes": [{"code": "C"}],
+        "vehicle_category_code": "C",
+        "issue_date": "2019-01-01",
+        "expiry_date": "2017-01-01"
+      }],
+      "un_distinguishing_sign": "USA",
+      "aka_suffix": "1ST",
+      "sex": 2,
+      "family_name_truncation": "N",
+      "given_name_truncation": "N"
+    }
   }
 }
         </pre>
@@ -293,11 +280,6 @@ This vocabulary assumes all terms specified in the base Verifiable Credentials
 [[VC-DATA-MODEL]] context. In addition, the following classes are available for
 specifying information related to ISO18013 data model compatible Driving
 Licenses.
-      </p>
-
-      <p>
-        All the terms below are defined under the
-        <code>org.iso.18013.5.1</code> namespace term.
       </p>
 
       <table class="simple">
@@ -503,9 +485,7 @@ This vocabulary extends the Verifiable Driver's License Core Vocabulary with
 terms for all data elements defined by the mDL Implementation Guidelines issued
 by the American Association of Motor Vehicle Administrators (AAMVA). It can be
 imported as a JSON-LD context behind the URL
-<a href="https://w3id.org/vdl/aamva/v1">https://w3id.org/vdl/aamva/v1</a>, where
-vocabulary terms are grouped under the <code>org.iso.18013.5.1.aamva</code>
-namespace term.
+<a href="https://w3id.org/vdl/aamva/v1">https://w3id.org/vdl/aamva/v1</a>.
       </p>
 
       <p>
@@ -523,97 +503,97 @@ namespace term.
         </thead>
         <tbody>
           <tr>
-            <td>aka_family_name_v2</td>
+            <td>aamva_aka_family_name_v2</td>
             <td>Alias / AKA family name</td>
             <td>Other family name by which credential holder is known.</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a> (latin1, 150 characters maximum)</td>
           </tr><tr>
-            <td>aka_given_name_v2</td>
+            <td>aamva_aka_given_name_v2</td>
             <td>Alias / AKA given name</td>
             <td>Other given name by which credential holder is known.</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a> (latin1, 150 characters maximum)</td>
           </tr><tr>
-            <td>aka_suffix</td>
+            <td>aamva_aka_suffix</td>
             <td>Alias / AKA Suffix name</td>
             <td>Other suffix by which credential holder is known. Allowed values are <code>JR</code>, <code>SR</code>, <code>1ST</code>, <code>I</code>, <code>2ND</code>, <code>II</code>, <code>3RD</code>, <code>III</code>, <code>4TH</code>, <code>IV</code>, <code>5TH</code>, <code>V</code>, <code>6TH</code>, <code>VI</code>, <code>7TH</code>, <code>VII</code>, <code>8TH</code>, <code>VIII</code>, <code>9TH</code> or <code>IX</code>.</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>cdl_indicator</td>
+            <td>aamva_cdl_indicator</td>
             <td>CDL indicator</td>
             <td>FMCSA required field that denotes whether the credential is a <q>Commercial Driver’s License</q> or a <q>Commercial Learner’s Permit</q>. This field is either absent or has value <code>1</code> (Commercial Driver’s License).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
           </tr><tr>
-            <td>dhs_compliance</td>
+            <td>aamva_dhs_compliance</td>
             <td>Compliance type.</td>
             <td>Indicates compliance with REAL ID. Allowed values are <code>F</code> (fully compliant) or <code>N</code> (non-compliant).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>dhs_compliance_text</td>
+            <td>aamva_dhs_compliance_text</td>
             <td>Non-REAL ID credential text</td>
             <td>Text, agreed on between the Issuing Authority and DHS, appearing on credentials not meeting REAL ID requirements.</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>dhs_temporary_lawful_status</td>
+            <td>aamva_dhs_temporary_lawful_status</td>
             <td>Limited duration document indicator</td>
             <td>Denotes whether the credential holder has temporary lawful status. This field is either absent or has value <code>1</code> (temporary lawful status).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
           </tr><tr>
-            <td>domestic_driving_privileges</td>
+            <td>aamva_domestic_driving_privileges</td>
             <td>Domestic categories of vehicles / restrictions / conditions.</td>
             <td>Vehicle types the license holder is authorized to operate.</td>
             <td><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON">JSON</a></td>
           </tr><tr>
-            <td>edl_credential</td>
+            <td>aamva_edl_credential</td>
             <td>EDL indicator</td>
             <td>Either absent or has one of the following values if the credential is an EDLc: <code>1</code> (Driver’s license) or <code>2</code> (Identification card).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
           </tr><tr>
-            <td>family_name_truncation</td>
+            <td>aamva_family_name_truncation</td>
             <td>Family name truncation</td>
             <td>Code that indicates whether the field has been truncated (<code>T</code>), has not been truncated (<code>N</code>), or unknown whether truncated (<code>U</code>).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>given_name_truncation</td>
+            <td>aamva_given_name_truncation</td>
             <td>Given name truncation</td>
             <td>Code that indicates whether either the first name or the middle name(s) have been truncated (<code>T</code>), have not been truncated (<code>N</code>), or unknown whether truncated (<code>U</code>).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>hazmat_endorsement_expiration_date</td>
+            <td>aamva_hazmat_endorsement_expiration_date</td>
             <td>HAZMAT endorsement expiration date</td>
             <td>Date on which the hazardous material endorsement granted by the document is no longer valid.</td>
             <td><a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 full-date</a></td>
           </tr><tr>
-            <td>name_suffix</td>
+            <td>aamva_name_suffix</td>
             <td>Name suffix</td>
             <td>Name suffix of the individual that has been issued the credential. Allowed values are <code>JR</code>, <code>SR</code>, <code>1ST</code>, <code>I</code>, <code>2ND</code>, <code>II</code>, <code>3RD</code>, <code>III</code>, <code>4TH</code>, <code>IV</code>, <code>5TH</code>, <code>V</code>, <code>6TH</code>, <code>VI</code>, <code>7TH</code>, <code>VII</code>, <code>8TH</code>, <code>VIII</code>, <code>9TH</code> or <code>IX</code>.</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>organ_donor</td>
+            <td>aamva_organ_donor</td>
             <td>Organ donor.</td>
             <td>Denotes whether the credential holder is an organ donor. This field is either absent or has value <code>1</code> (Donor).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
           </tr><tr>
-            <td>race_ethnicity</td>
+            <td>aamva_race_ethnicity</td>
             <td>Race / ethnicity.</td>
             <td>Codes for race or ethnicity of the credential holder, as defined in AAMVA D20.</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>resident_county</td>
+            <td>aamva_resident_county</td>
             <td>Resident county</td>
             <td>The 3-digit county code of the county where the credential holder lives, as per the 2010 FIPS Codes for Counties and County Equivalent Entities.</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-            <td>sex</td>
+            <td>aamva_sex</td>
             <td>Credential holder’s sex.</td>
             <td>In line with the AAMVA Card Design Specification, this element can have one of the following values: <code>1</code> (Male), <code>2</code> (Female) or <code>9</code> (Not Specified).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
           </tr><tr>
-            <td>veteran</td>
+            <td>aamva_veteran</td>
             <td>Whether the credential holder is a veteran.</td>
             <td>This field is either absent or has value <code>1</code> (Veteran).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
           </tr><tr>
-            <td>weight_range</td>
+            <td>aamva_weight_range</td>
             <td>Weight range</td>
             <td>Indicates the approximate weight range of the credential holder: <code>0</code> (up to 31 kg), <code>1</code> (32 – 45 kg), <code>2</code> (46 - 59 kg), <code>3</code> (60 - 70 kg), <code>4</code> (71 - 86 kg), <code>5</code> (87 - 100 kg), <code>6</code> (101 - 113 kg), <code>7</code> (114 - 127 kg), <code>8</code> (128 – 145 kg), <code>9</code> (146+ kg).</td>
             <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,8 @@ Compatability with the W3C Verifiable Credentials data model.
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/vdl/v1"
+    "https://w3id.org/vdl/v1",
+    "https://w3id.org/vdl/aamva/v1"
   ],
   "type": [
     "VerifiableCredential",
@@ -153,30 +154,38 @@ Compatability with the W3C Verifiable Credentials data model.
   "expirationDate": "2022-08-27T12:00:00.0000000-06:00",
   "credentialSubject": {
     "id": "did:example:12347abcd",
-    "license": {
+    "driversLicense": {
       "type": "Iso18013DriversLicense",
-      "document_number": "542426814",
-      "family_name": "TURNER",
-      "given_name": "SUSAN",
-      "portrait": "/9j/4AAQSkZJRgABAQEAkACQA...gcdgck5HtRRSClooooP/2Q==",
-      "birth_date": "1998-08-28",
-      "issue_date": "2018-01-15T10:00:00.0000000-07:00",
-      "expiry_date": "2022-08-27T12:00:00.0000000-06:00",
-      "issuing_country": "US",
-      "issuing_authority": "CO",
-      "driving_privileges": [{
-        "codes": [{"code": "D"}],
-        "vehicle_category_code": "D",
-        "issue_date": "2019-01-01",
-        "expiry_date": "2027-01-01"
+      "org.iso.18013.5.1": {
+        "document_number": "542426814",
+        "family_name": "TURNER",
+        "given_name": "SUSAN",
+        "portrait": "/9j/4AAQSkZJRgABAQEAkACQA...gcdgck5HtRRSClooooP/2Q==",
+        "birth_date": "1998-08-28",
+        "issue_date": "2018-01-15T10:00:00.0000000-07:00",
+        "expiry_date": "2022-08-27T12:00:00.0000000-06:00",
+        "issuing_country": "US",
+        "issuing_authority": "CO",
+        "driving_privileges": [{
+          "codes": [{"code": "D"}],
+          "vehicle_category_code": "D",
+          "issue_date": "2019-01-01",
+          "expiry_date": "2027-01-01"
+        },
+        {
+          "codes": [{"code": "C"}],
+          "vehicle_category_code": "C",
+          "issue_date": "2019-01-01",
+          "expiry_date": "2017-01-01"
+        }],
+        "un_distinguishing_sign": "USA",
       },
-      {
-        "codes": [{"code": "C"}],
-        "vehicle_category_code": "C",
-        "issue_date": "2019-01-01",
-        "expiry_date": "2017-01-01"
-      }],
-      "un_distinguishing_sign": "USA",
+      "org.iso.18013.5.1.aamva": {
+        "aka_suffix": "1ST",
+        "sex": 2,
+        "family_name_truncation": "N",
+        "given_name_truncation": "N"
+      }
     },
   },
   "proof": {
@@ -277,7 +286,7 @@ TBD
     </section>
 
     <section class="normative">
-      <h2>The Verifiable Driver's License Vocabulary</h2>
+      <h2>The Verifiable Driver's License Core Vocabulary</h2>
 
       <p>
 This vocabulary assumes all terms specified in the base Verifiable Credentials
@@ -286,131 +295,328 @@ specifying information related to ISO18013 data model compatible Driving
 Licenses.
       </p>
 
+      <p>
+        All the terms below are defined under the
+        <code>org.iso.18013.5.1</code> namespace term.
+      </p>
+
       <table class="simple">
         <thead>
           <tr>
             <th>Identifier</th>
             <th>Field Name</th>
             <th>Field Description</th>
+            <th>Data Type</th>
           </tr>
         </thead>
         <tbody>
           <tr>
           <td>family_name</td>
           <td>Family name</td>
-          <td>Last name, surname, or primary identifier, of the licence holder.
+          <td>Last name, surname, or primary identifier, of the licence holder.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>given_name</td>
           <td>Given names</td>
-          <td>First name(s), other name(s), or secondary identifier, of the licence holder.
+          <td>First name(s), other name(s), or secondary identifier, of the licence holder.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>birth_date</td>
           <td>Date of birth</td>
-          <td>Day, month, year on which the licence holder was born. If unknown, approximate.
+          <td>Day, month, year on which the licence holder was born. If unknown, approximate.</td>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 full-date</a></td>
           </tr><tr>
           <td>issue_date</td>
           <td>Date of Issue</td>
-          <td>Date licence document was issued.
+          <td>Date licence document was issued.</td>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 date-time</a> or <a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 full-date</a></td>
           </tr><tr>
           <td>expiry_date</td>
           <td>Date of Expiry</td>
-          <td>Date licence document expires.
+          <td>Date licence document expires.</td>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 date-time</a> or <a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 full-date</a></td>
           </tr><tr>
           <td>issuing_country</td>
           <td>Issuing country</td>
-          <td>Country code as alpha 2 code, defined in ISO 3166-1, which issued the mDL or within which the licensing authority is located.
+          <td>Country code as alpha 2 code, defined in ISO 3166-1, which issued the mDL or within which the licensing authority is located.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>issuing_authority</td>
           <td>Issuing authority</td>
-          <td>Name of licensing authority, or issuing country if separate licensing authorities have not been authorized.
+          <td>Name of licensing authority, or issuing country if separate licensing authorities have not been authorized.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>document_number</td>
           <td>Licence number</td>
-          <td>The number assigned or calculated by the issuing authority.
+          <td>The number assigned or calculated by the issuing authority.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>administrative_number</td>
           <td>Administrative number</td>
-          <td>An audit control number assigned by the licensing authority
+          <td>An audit control number assigned by the licensing authority</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>driving_privileges</td>
           <td>Categories of vehicles/restrictions/conditions</td>
-          <td>Driving privileges the licence holder is authorized to drive. It consists of category issue date, expiry date, restriction/condition sign code, restriction/condition sign and restriction/condition value.
+          <td>Driving privileges the licence holder is authorized to drive. It consists of category issue date, expiry date, restriction/condition sign code, restriction/condition sign and restriction/condition value.</td>
+          <td><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON">JSON</a></td>
           </tr><tr>
           <td>un_distinguishing_sign</td>
           <td>UN distinguishing sign</td>
-          <td>Distinguishing sign of the issuing country according to 18013-1 annex F NOTE this field is added for purposes of the UN conventions on driving licences.
+          <td>Distinguishing sign of the issuing country according to 18013-1 annex F NOTE this field is added for purposes of the UN conventions on driving licences.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-          <td>gender</td>
-          <td>Gender</td>
-          <td>Licence holder’s gender: M for male, F for female, X for not specified
+          <td>sex</td>
+          <td>Sex</td>
+          <td>Licence holder’s sex using values as defined in ISO/IEC 5218.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32 bits unsigned integer number</a></td>
           </tr><tr>
           <td>height</td>
           <td>Height (cm)</td>
-          <td>A Licence holder’s height in centimetres.
+          <td>A Licence holder’s height in centimetres.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32 bits unsigned integer number</a></td>
           </tr><tr>
           <td>weight</td>
           <td>Weight (kg)</td>
-          <td>A Licence holder’s weight in kilograms O F3N uint
+          <td>A Licence holder’s weight in kilograms O F3N uint.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32 bits unsigned integer number</a></td>
           </tr><tr>
-          <td>eye_color</td>
+          <td>eye_colour</td>
           <td>Eye colour</td>
-          <td>Licence holder’s eye colour: blue, brown, black, hazel, green, grey, pink, dichromatic.
+          <td>Licence holder’s eye colour: black, blue, brown, dichromatic, grey, green, hazel, maroon, pink or unknown.
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-          <td>hair_color</td>
+          <td>hair_colour</td>
           <td>Hair colour</td>
-          <td>Licence holder’s hair colour: brown, black, blonde, grey, red, auburn, sandy, white, bald.
+          <td>Licence holder’s hair colour: bald, black, blond, brown, grey, red, auburn, sandy, white or unknown.
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>birth_place</td>
           <td>Place of birth</td>
-          <td>Country and municipality or state/province where the licence holder was born.
+          <td>Country and municipality or state/province where the licence holder was born.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>resident_address</td>
           <td>Permanent place of residence</td>
-          <td>The place where the licence holder resides and/or may be contacted (street/house number, municipality etc.)
+          <td>The place where the licence holder resides and/or may be contacted (street/house number, municipality etc.)</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>portrait</td>
           <td>Portrait of mDL Holder</td>
-          <td>A reproduction of the licence holder’s portrait.
+          <td>A reproduction of the licence holder’s portrait.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#base64Binary">Base 64</a></td>
           </tr><tr>
           <td>portrait_capture_date</td>
           <td>Portrait image timestamp</td>
-          <td>Date when picture was taken.
+          <td>Date when picture was taken.</td>
+          <td><a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 date-time</a></td>
           </tr><tr>
           <td>age_in_years</td>
           <td>Age attestation: How old are you (in years)?</td>
-          <td>The age of the mDL Holder.
+          <td>The age of the mDL Holder.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32 bits unsigned integer number</a></td>
+          </tr><tr>
+          <td>age_over_18</td>
+          <td>Age attestation: Nearest “true” attestation above 18.</td>
+          <td>Is the holder over 18.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#boolean">Boolean</a></td>
+          </tr><tr>
+          <td>age_over_21</td>
+          <td>Age attestation: Nearest “true” attestation above 21.</td>
+          <td>Is the holder over 21.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#boolean">Boolean</a></td>
+          </tr><tr>
+          <td>age_over_25</td>
+          <td>Age attestation: Nearest “true” attestation above 25.</td>
+          <td>Is the holder over 25.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#boolean">Boolean</a></td>
+          </tr><tr>
+          <td>age_over_62</td>
+          <td>Age attestation: Nearest “true” attestation above 62.</td>
+          <td>Is the holder over 62.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#boolean">Boolean</a></td>
+          </tr><tr>
+          <td>age_over_65</td>
+          <td>Age attestation: Nearest “true” attestation above 65.</td>
+          <td>Is the holder over 65.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#boolean">Boolean</a></td>
           </tr><tr>
           <td>age_birth_year</td>
           <td>Age attestation: In what year were you born?</td>
-          <td>The year when the mDL Holder was born.
+          <td>The year when the mDL Holder was born.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32 bits unsigned integer number</a></td>
           </tr><tr>
           <td>issuing_jurisdiction</td>
           <td>Issuing jurisdiction</td>
-          <td>Country subdivision code as defined in clause 8, ISO 3166-2. The first part of the code shall be the same as the value for issuing_country. This element is intended to be used in cases where the issuing jurisdiction is different from the issuing authority.
+          <td>Country subdivision code as defined in clause 8, ISO 3166-2. The first part of the code shall be the same as the value for issuing_country. This element is intended to be used in cases where the issuing jurisdiction is different from the issuing authority.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>nationality</td>
           <td>Nationality</td>
           <td>Nationality of the mDL Holder as two letter country code (alpha-2 code) defined in ISO 3166-1.
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>resident_city</td>
           <td>Resident city</td>
-          <td>The city where the mDL Holder lives.
+          <td>The city where the mDL Holder lives.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+          <td>resident_country</td>
+          <td>Resident country</td>
+          <td>The country where the mDL Holder lives.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>resident_state</td>
           <td>Resident state/province/district</td>
-          <td>The state/province/district where the mDL Holder lives.
+          <td>The state/province/district where the mDL Holder lives.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>resident_postal_code</td>
           <td>Resident postal code</td>
-          <td>The postal code of the mDL Holder.
+          <td>The postal code of the mDL Holder.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
-          <td>name_national_character</td>
-          <td>Full name of holder in full UTF-8 character set</td>
-          <td>The full name of the mDL Holder in his/her national characters.
+          <td>family_name_national_character</td>
+          <td>Family name of holder in full UTF-8 character set</td>
+          <td>The family name of the mDL Holder in his/her national characters.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+          <td>given_name_national_character</td>
+          <td>Given name of holder in full UTF-8 character set</td>
+          <td>The given name of the mDL Holder in his/her national characters.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
           </tr><tr>
           <td>signature_usual_mark</td>
           <td>Signature / usual mark</td>
-          <td>Image of the signature or usual mark of the mDL Holder.
+          <td>Image of the signature or usual mark of the mDL Holder.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#base64Binary">Base 64</a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <section class="normative">
+      <h2>The Verifiable Driver's License AAMVA Vocabulary</h2>
+
+      <p>
+This vocabulary extends the Verifiable Driver's License Core Vocabulary with
+terms for all data elements defined by the mDL Implementation Guidelines issued
+by the American Association of Motor Vehicle Administrators (AAMVA). It can be
+imported as a JSON-LD context behind the URL
+<a href="https://w3id.org/vdl/aamva/v1">https://w3id.org/vdl/aamva/v1</a>, where
+vocabulary terms are grouped under the <code>org.iso.18013.5.1.aamva</code>
+namespace term.
+      </p>
+
+      <p>
+        
+      </p>
+
+      <table class="simple">
+        <thead>
+          <tr>
+            <th>Identifier</th>
+            <th>Field Name</th>
+            <th>Field Description</th>
+            <th>Data Type</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>aka_family_name_v2</td>
+            <td>Alias / AKA family name</td>
+            <td>Other family name by which credential holder is known.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a> (latin1, 150 characters maximum)</td>
+          </tr><tr>
+            <td>aka_given_name_v2</td>
+            <td>Alias / AKA given name</td>
+            <td>Other given name by which credential holder is known.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a> (latin1, 150 characters maximum)</td>
+          </tr><tr>
+            <td>aka_suffix</td>
+            <td>Alias / AKA Suffix name</td>
+            <td>Other suffix by which credential holder is known. Allowed values are <code>JR</code>, <code>SR</code>, <code>1ST</code>, <code>I</code>, <code>2ND</code>, <code>II</code>, <code>3RD</code>, <code>III</code>, <code>4TH</code>, <code>IV</code>, <code>5TH</code>, <code>V</code>, <code>6TH</code>, <code>VI</code>, <code>7TH</code>, <code>VII</code>, <code>8TH</code>, <code>VIII</code>, <code>9TH</code> or <code>IX</code>.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>cdl_indicator</td>
+            <td>CDL indicator</td>
+            <td>FMCSA required field that denotes whether the credential is a <q>Commercial Driver’s License</q> or a <q>Commercial Learner’s Permit</q>. This field is either absent or has value <code>1</code> (Commercial Driver’s License).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
+          </tr><tr>
+            <td>dhs_compliance</td>
+            <td>Compliance type.</td>
+            <td>Indicates compliance with REAL ID. Allowed values are <code>F</code> (fully compliant) or <code>N</code> (non-compliant).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>dhs_compliance_text</td>
+            <td>Non-REAL ID credential text</td>
+            <td>Text, agreed on between the Issuing Authority and DHS, appearing on credentials not meeting REAL ID requirements.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>dhs_temporary_lawful_status</td>
+            <td>Limited duration document indicator</td>
+            <td>Denotes whether the credential holder has temporary lawful status. This field is either absent or has value <code>1</code> (temporary lawful status).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
+          </tr><tr>
+            <td>domestic_driving_privileges</td>
+            <td>Domestic categories of vehicles / restrictions / conditions.</td>
+            <td>Vehicle types the license holder is authorized to operate.</td>
+            <td><a href="http://www.w3.org/1999/02/22-rdf-syntax-ns#JSON">JSON</a></td>
+          </tr><tr>
+            <td>edl_credential</td>
+            <td>EDL indicator</td>
+            <td>Either absent or has one of the following values if the credential is an EDLc: <code>1</code> (Driver’s license) or <code>2</code> (Identification card).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
+          </tr><tr>
+            <td>family_name_truncation</td>
+            <td>Family name truncation</td>
+            <td>Code that indicates whether the field has been truncated (<code>T</code>), has not been truncated (<code>N</code>), or unknown whether truncated (<code>U</code>).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>given_name_truncation</td>
+            <td>Given name truncation</td>
+            <td>Code that indicates whether either the first name or the middle name(s) have been truncated (<code>T</code>), have not been truncated (<code>N</code>), or unknown whether truncated (<code>U</code>).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>hazmat_endorsement_expiration_date</td>
+            <td>HAZMAT endorsement expiration date</td>
+            <td>Date on which the hazardous material endorsement granted by the document is no longer valid.</td>
+            <td><a href="https://www.rfc-editor.org/rfc/rfc3339#section-5.6">RFC3339 full-date</a></td>
+          </tr><tr>
+            <td>name_suffix</td>
+            <td>Name suffix</td>
+            <td>Name suffix of the individual that has been issued the credential. Allowed values are <code>JR</code>, <code>SR</code>, <code>1ST</code>, <code>I</code>, <code>2ND</code>, <code>II</code>, <code>3RD</code>, <code>III</code>, <code>4TH</code>, <code>IV</code>, <code>5TH</code>, <code>V</code>, <code>6TH</code>, <code>VI</code>, <code>7TH</code>, <code>VII</code>, <code>8TH</code>, <code>VIII</code>, <code>9TH</code> or <code>IX</code>.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>organ_donor</td>
+            <td>Organ donor.</td>
+            <td>Denotes whether the credential holder is an organ donor. This field is either absent or has value <code>1</code> (Donor).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
+          </tr><tr>
+            <td>race_ethnicity</td>
+            <td>Race / ethnicity.</td>
+            <td>Codes for race or ethnicity of the credential holder, as defined in AAMVA D20.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>resident_county</td>
+            <td>Resident county</td>
+            <td>The 3-digit county code of the county where the credential holder lives, as per the 2010 FIPS Codes for Counties and County Equivalent Entities.</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#string">String</a></td>
+          </tr><tr>
+            <td>sex</td>
+            <td>Credential holder’s sex.</td>
+            <td>In line with the AAMVA Card Design Specification, this element can have one of the following values: <code>1</code> (Male), <code>2</code> (Female) or <code>9</code> (Not Specified).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
+          </tr><tr>
+            <td>veteran</td>
+            <td>Whether the credential holder is a veteran.</td>
+            <td>This field is either absent or has value <code>1</code> (Veteran).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
+          </tr><tr>
+            <td>weight_range</td>
+            <td>Weight range</td>
+            <td>Indicates the approximate weight range of the credential holder: <code>0</code> (up to 31 kg), <code>1</code> (32 – 45 kg), <code>2</code> (46 - 59 kg), <code>3</code> (60 - 70 kg), <code>4</code> (71 - 86 kg), <code>5</code> (87 - 100 kg), <code>6</code> (101 - 113 kg), <code>7</code> (114 - 127 kg), <code>8</code> (128 – 145 kg), <code>9</code> (146+ kg).</td>
+            <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32bits unsigned integer number</a></td>
           </tr>
         </tbody>
       </table>


### PR DESCRIPTION
This PR tries to bring the VDL vocabulary closer to the ISO mDL data-model by:
  - removing properties not in ISO mDL,
  - adding properties missing from ISO mDL,
  - adding missing datatypes and using the same datatypes as ISO mDL when possible.

It also adds a vocabulary and separate context for the AAMVA namespace (`org.iso.18013.5.1.aamva`).

Some other general improvements:
  - Use camelCase in properties URLs (RDF standard).
  - Renamed `license` into `driversLicense` to avoid collisions.
  - Added a "Data type" column in tables.

# Datatypes

I have added datatypes to the terms specification, trying use common RDF datatypes (XSD datatypes) matching the ISO mDL specification. For some of them, I couldn't find a suitable datatype.

## Date and time

Terms like `birth_date` or `expiry_date` use a date or time using [RFC3339](https://www.rfc-editor.org/rfc/rfc3339), either referring to the `full-date` production or the union of `date-time` and `full-date`. In the context definition I refer to the former with the `https://www.rfc-editor.org/rfc/rfc3339#full-date` URL and to the later with the `https://w3id.org/vdl#date-time-or-full-date`. I don't have an issue with the first URL, but the second one might require an RDF definition to be included in the VDL specification, which may look like this:
```nquads
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix rfc3339: <https://www.rfc-editor.org/rfc/rfc3339#> .
@prefix vdl: <https://w3id.org/vdl#> .

vdl:date-time-or-full-date a rdfs:Datatype;
  owl:unionOf (
    rfc3339:date-time
    rfc3339:full-date
  ) .
```

## Binary data

Some properties values like `portrait` are represented using raw binary data in the ISO mDL datamodel. It is not possible to transport raw bytes in RDF or JSON. In this case I used the `http://www.w3.org/2001/XMLSchema#base64Binary` datatype, meaning the raw bytes should be encoded in Base64. Another option could be `http://www.w3.org/2001/XMLSchema#hexBinary`.

# Property patterns

The ISO mDL datamodel specifies families of properties sharing the same pattern, like `age_over_NN`. Since we can't define such patterns in a JSON-LD context, only a subset of them are defined. I tried to select ages that makes the most sense: 18, 21, 25, 62 and 65.

# AAMVA terms

To avoid collision, all the AAMVA terms are prefixed with `aamva_`. The URLs of the associated properties all start with `https://w3id.org/vdl/aamva#`.