### PR TITLE
Fix the examples credentials type

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,7 @@ Compatability with the W3C Verifiable Credentials data model.
   ],
   "type": [
     "VerifiableCredential",
-    "Iso18013DriversLicense"
+    "Iso18013DriversLicenseCredential"
   ],
   "issuer": "did:key:z6MkjxvA4FNrQUhr8f7xhdQuP1VPzErkcnfxsRaU5oFgy2E5",
   "issuanceDate": "2018-01-15T10:00:00.0000000-07:00",
@@ -214,7 +214,7 @@ modelled in a way that is in keeping with the W3C Verifiable Credentials standar
   ],
   "type": [
     "VerifiableCredential",
-    "Iso18013DriversLicense"
+    "Iso18013DriversLicenseCredential"
   ],
   "issuer": "did:key:z6MkjxvA4FNrQUhr8f7xhdQuP1VPzErkcnfxsRaU5oFgy2E5",
   "issuanceDate": "2018-01-15T10:00:00.0000000-07:00",


### PR DESCRIPTION
The examples are using the wrong type for the credentials (`Iso18013DriversLicense` instead of `Iso18013DriversLicenseCredential`). This PR fixes the issue.