### PR TITLE
Update to v2 version of vdl context.

### DIFF
--- a/context/v1.jsonld
+++ b/context/v1.jsonld
@@ -103,6 +103,22 @@
           "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         }
       }
-    }
+    },
+    "OpticalBarcodeCredential": "https://w3id.org/vdl#OpticalBarcodeCredential",
+    "TerseBitstringStatusListEntry": {
+        "@id": "https://w3id.org/vdl#TerseBitstringStatusListEntry",
+        "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "terseStatusListIndex": "https://w3id.org/vdl#terseStatusListIndex",
+            "terseStatusListBaseUrl": "https://w3id.org/vdl#terseStatusListBaseUrl"
+        }
+      },
+      "AamvaDriversLicenseScannableInformation": "https://w3id.org/vdl#AamvaDriversLicenseScannableInformation",
+      "protectedComponentIndex": {
+        "@id":"https://w3id.org/cadmv#protectedComponentIndex",
+        "@type":"https://w3id.org/security#multibase"
+      }
   }
 }

--- a/context/v2.jsonld
+++ b/context/v2.jsonld
@@ -103,6 +103,22 @@
           "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
         }
       }
-    }
+    },
+    "OpticalBarcodeCredential": "https://w3id.org/vdl#OpticalBarcodeCredential",
+    "TerseBitstringStatusListEntry": {
+        "@id": "https://w3id.org/vdl#TerseBitstringStatusListEntry",
+        "@context": {
+            "@protected": true,
+            "id": "@id",
+            "type": "@type",
+            "terseStatusListIndex": "https://w3id.org/vdl#terseStatusListIndex",
+            "terseStatusListBaseUrl": "https://w3id.org/vdl#terseStatusListBaseUrl"
+        }
+      },
+      "AamvaDriversLicenseScannableInformation": "https://w3id.org/vdl#AamvaDriversLicenseScannableInformation",
+      "protectedComponentIndex": {
+        "@id":"https://w3id.org/cadmv#protectedComponentIndex",
+        "@type":"https://w3id.org/security#multibase"
+      }
   }
 }

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ Compatability with the W3C Verifiable Credentials data model.
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/vdl/v1",
+    "https://w3id.org/vdl/v2",
     "https://w3id.org/vdl/aamva/v1"
   ],
   "type": [


### PR DESCRIPTION
adds types:
- OpticalBarcodeCredential
- TerseBitstringStatusListEntry
- AamvaDriversLicenseScannableInformation
adds properties:
- terseStatusListIndex
- terseStatusListBaseUrl
- protectedComponentIndex

These additions are to support the [Verifiable Credential Barcodes](https://digitalbazaar.github.io/vc-barcodes/) work.
- TerseBitstringStatusListEntry, terseStatusListIndex, and terseStatusListBaseUrl provide a space-efficient mechanism to use [Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/) for status on driver's licenses.
- OpticalBarcodeCredential is a credential type used for securing data in an optical barcode, such as the PDF417 in a driver's license.
- AamvaDriversLicenseScannableInformation and protectedComponentIndex support securing AAMVA compliant PDF417s.