### PR TITLE
Update vdl vocab to v2.

### DIFF
--- a/context/v2.jsonld
+++ b/context/v2.jsonld
@@ -1,0 +1,121 @@
+{
+  "@context": {
+    "@protected": true,
+    "id": "@id",
+    "type": "@type",
+    "name": "https://schema.org/name",
+    "description": "https://schema.org/description",
+    "image": {
+      "@id": "https://schema.org/image",
+      "@type": "@id"
+    },
+    "url": {
+      "@id": "https://schema.org/url",
+      "@type": "@id"
+    },
+    "Iso18013DriversLicenseCredential": "https://w3id.org/vdl#Iso18013DriversLicenseCredential",
+    "LicensedDriver": {
+      "@id": "https://w3id.org/vdl#LicensedDriver",
+      "@type": "@id",
+      "@context": {
+        "@protected": true,
+        "driversLicense": {
+          "@id": "https://w3id.org/vdl#license",
+          "@type": "@id"
+        }
+      }
+    },
+    "Iso18013DriversLicense": {
+      "@id": "https://w3id.org/vdl#Iso18013DriversLicense",
+      "@context": {
+        "@protected": true,
+        "administrative_number": "https://w3id.org/vdl#administrativeNumber",
+        "age_birth_year": {
+          "@id": "https://w3id.org/vdl#ageBirthYear",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "age_in_years": {
+          "@id": "https://w3id.org/vdl#ageInYears",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "age_over_18": "https://w3id.org/vdl#ageOver18",
+        "age_over_21": "https://w3id.org/vdl#ageOver21",
+        "age_over_25": "https://w3id.org/vdl#ageOver25",
+        "age_over_62": "https://w3id.org/vdl#ageOver62",
+        "age_over_65": "https://w3id.org/vdl#ageOver65",
+        "birth_date": {
+          "@id": "https://w3id.org/vdl#birthDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "birth_place": "https://w3id.org/vdl#birthPlace",
+        "document_number": "https://w3id.org/vdl#documentNumber",
+        "driving_privileges": {
+          "@id": "https://w3id.org/vdl#drivingPrivileges",
+          "@type": "@json"
+        },
+        "expiry_date": {
+          "@id": "https://w3id.org/vdl#expiryDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "eye_colour": "https://w3id.org/vdl#eyeColour",
+        "family_name": "https://w3id.org/vdl#familyName",
+        "family_name_national_character": "https://w3id.org/vdl#familyNameNationalCharacter",
+        "given_name": "https://w3id.org/vdl#givenName",
+        "given_name_national_character": "https://w3id.org/vdl#givenNameNationalCharacter",
+        "hair_colour": "https://w3id.org/vdl#hairColour",
+        "height": {
+          "@id": "https://w3id.org/vdl#height",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "issue_date": {
+          "@id": "https://w3id.org/vdl#issueDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "issuing_authority": "https://w3id.org/vdl#issuingAuthority",
+        "issuing_country": "https://w3id.org/vdl#issuingCountry",
+        "issuing_jurisdiction": "https://w3id.org/vdl#issuingJurisdiction",
+        "nationality": "https://w3id.org/vdl#nationality",
+        "portrait": {
+          "@id": "https://w3id.org/vdl#portrait",
+          "@type": "@id"
+        },
+        "portrait_capture_date": {
+          "@id": "https://w3id.org/vdl#portraitCaptureDate",
+          "@type": "http://www.w3.org/2001/XMLSchema#dateTime"
+        },
+        "resident_address": "https://w3id.org/vdl#residentAddress",
+        "resident_city": "https://w3id.org/vdl#residentCity",
+        "resident_country": "https://w3id.org/vdl#residentCountry",
+        "resident_postal_code": "https://w3id.org/vdl#residentPostalCode",
+        "resident_state": "https://w3id.org/vdl#residentState",
+        "sex": {
+          "@id": "https://w3id.org/vdl#sex",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        },
+        "signature_usual_mark": {
+          "@id": "https://w3id.org/vdl#signatureUsualMark",
+          "@type": "@id"
+        },
+        "un_distinguishing_sign": "https://w3id.org/vdl#unDistinguishingSign",
+        "weight": {
+          "@id": "https://w3id.org/vdl#weight",
+          "@type": "http://www.w3.org/2001/XMLSchema#unsignedInt"
+        }
+      }
+    },
+    "OpticalBarcodeCredential": "https://w3id.org/vdl#OpticalBarcodeCredential",
+    "TerseBitstringStatusListEntry": {
+      "@id": "https://w3id.org/vdl#TerseBitstringStatusListEntry",
+      "@context": {
+        "@protected": true,
+        "id": "@id",
+        "type": "@type",
+        "terseStatusListBaseUrl": {
+          "@type": "@id",
+          "@id": "https://w3id.org/vdl#terseStatusListBaseUrl"
+        },
+        "terseStatusListIndex": "https://w3id.org/vdl#terseStatusListIndex"
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -424,6 +424,16 @@ Licenses.
           <td>Signature / usual mark</td>
           <td>Image of the signature or usual mark of the mDL Holder.</td>
           <td><a href="http://www.w3.org/2001/XMLSchema#base64Binary">Base 64</a></td>
+          </tr><tr>
+          <td>terseStatusListBaseUrl</td>
+          <td>Terse Status List Base URL</td>
+          <td>The base URL location of a status list.</td>
+          <td>URL</td>
+          </tr><tr>
+          <td>terseStatusListIndex</td>
+          <td>Terse Status List Index</td>
+          <td>An index within a status list.</td>
+          <td><a href="http://www.w3.org/2001/XMLSchema#unsignedInt">32 bits unsigned integer number</a></td>
           </tr>
         </tbody>
       </table>

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@ Compatability with the W3C Verifiable Credentials data model.
 {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://w3id.org/vdl/v1",
+    "https://w3id.org/vdl/v2",
     "https://w3id.org/vdl/aamva/v1"
   ],
   "type": [


### PR DESCRIPTION
This PR does the following in support of the [Verifiable Credential Barcodes](https://digitalbazaar.github.io/vc-barcodes/) work:
- adds OpticalBarcodeCredential, a credential type used for securing data in an optical barcode, such as the PDF417 in a driver's license.
- adds TerseBitstringStatusListEntry, terseStatusListIndex, and terseStatusListBaseUrl, which together provide a space-efficient mechanism to use [Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/) for status on driver's licenses.
- updates the data model to contain the additions above.